### PR TITLE
Pulling timezoneInfo from TimezoneId provided in config as well as ne…

### DIFF
--- a/MIFCore.Hangfire/IRecurringJobManagerExtensions.cs
+++ b/MIFCore.Hangfire/IRecurringJobManagerExtensions.cs
@@ -7,24 +7,24 @@ namespace MIFCore.Hangfire
 {
     public static class IRecurringJobManagerExtensions
     {
-        public static void CreateRecurringJob(this IRecurringJobManager recurringJobManager, string jobName, Expression<Func<Task>> methodCall, string cronSchedule = null, string queue = "default", bool triggerIfNeverExecuted = false)
+        public static void CreateRecurringJob(this IRecurringJobManager recurringJobManager, string jobName, Expression<Func<Task>> methodCall, string cronSchedule = null, string queue = "default", bool triggerIfNeverExecuted = false, TimeZoneInfo timeZone = null)
         {
             var manager = recurringJobManager as MIFCoreRecurringJobManager;
 
             if (manager is null)
                 throw new ArgumentException("Parameter 'recurringJobManager' is not of type 'MIFCore.Hangfire.MIFCoreRecurringJobManager'");
             
-            manager.CreateRecurringJob(jobName: jobName, methodCall: methodCall, cronSchedule: cronSchedule, queue: queue, triggerIfNeverExecuted: triggerIfNeverExecuted);
+            manager.CreateRecurringJob(jobName: jobName, methodCall: methodCall, cronSchedule: cronSchedule, queue: queue, triggerIfNeverExecuted: triggerIfNeverExecuted, timeZone: timeZone);
         }
 
-        public static void CreateRecurringJob<T>(this IRecurringJobManager recurringJobManager, string jobName, Expression<Func<T, Task>> methodCall, string cronSchedule = null, string queue = "default", bool triggerIfNeverExecuted = false)
+        public static void CreateRecurringJob<T>(this IRecurringJobManager recurringJobManager, string jobName, Expression<Func<T, Task>> methodCall, string cronSchedule = null, string queue = "default", bool triggerIfNeverExecuted = false, TimeZoneInfo timeZone = null)
         {
             var manager = recurringJobManager as MIFCoreRecurringJobManager;
 
             if (manager is null)
                 throw new ArgumentException("Parameter 'recurringJobManager' is not of type 'MIFCore.Hangfire.MIFCoreRecurringJobManager'");
 
-            manager.CreateRecurringJob<T>(jobName: jobName, methodCall: methodCall, cronSchedule: cronSchedule, queue: queue, triggerIfNeverExecuted: triggerIfNeverExecuted);
+            manager.CreateRecurringJob<T>(jobName: jobName, methodCall: methodCall, cronSchedule: cronSchedule, queue: queue, triggerIfNeverExecuted: triggerIfNeverExecuted, timeZone: timeZone);
         }
     }
 }

--- a/MIFCore.TestApp/MIFCore.TestApp.csproj
+++ b/MIFCore.TestApp/MIFCore.TestApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -15,7 +15,7 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="settings.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
 

--- a/MIFCore.TestApp/SomeJob.cs
+++ b/MIFCore.TestApp/SomeJob.cs
@@ -1,4 +1,5 @@
 ﻿using Hangfire;
+using Hangfire.Annotations;
 using MIFCore.Hangfire;
 using System;
 using System.Threading.Tasks;
@@ -22,6 +23,14 @@ namespace MIFCore.TestApp
 
             Console.WriteLine("yees");
             this.backgroundJobClient.Enqueue<SomeJob>(y => y.DoTheNextJob());
+
+            return Task.CompletedTask;
+        }
+
+        public Task DingleDog([NotNull] string dingledog) {
+            var current = BackgroundJobContext.Current;
+
+            Console.WriteLine($"dingledog: {dingledog}");
 
             return Task.CompletedTask;
         }

--- a/MIFCore.TestApp/Startup.cs
+++ b/MIFCore.TestApp/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Hangfire;
 using MIFCore.Hangfire;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace MIFCore.TestApp
 {
@@ -10,6 +11,8 @@ namespace MIFCore.TestApp
         {
             serviceDescriptors.AddScoped<SomeJob>();
             serviceDescriptors.AddControllers();
+
+            
         }
 
         public void Configure()
@@ -19,7 +22,13 @@ namespace MIFCore.TestApp
 
         public void PostConfigure(IBackgroundJobClient backgroundJobClient, IRecurringJobManager recurringJobManager)
         {
-            recurringJobManager.CreateRecurringJob<SomeJob>("some-job", y => y.DoTheJob(), Cron.Monthly());
+            recurringJobManager.CreateRecurringJob<SomeJob>("some-job", y => y.DoTheJob(), cronSchedule: "*/5 * * * *");
+            recurringJobManager.CreateRecurringJob<SomeJob>("some-goober-boy", y => y.DingleDog("goober"), cronSchedule: "*/5 * * * *");
+            
+            // This doesn't seem to run due to the queue?
+            recurringJobManager.CreateRecurringJob<SomeJob>("some-bigboi", y => y.DingleDog("biggest-boi"), cronSchedule: "*/5 * * * *", queue: "bigboi");
+            
+
             recurringJobManager.CreateRecurringJob<SomeJob>("some-job-triggered", y => y.TriggeredJobAction(), Cron.Monthly());
 
             backgroundJobClient.Enqueue<SomeJob>(y => y.DoTheJob());

--- a/MIFCore.TestApp/settings.json
+++ b/MIFCore.TestApp/settings.json
@@ -1,7 +1,15 @@
 {
   "connectionString": "",
-  "bindingPort": 80,
-  "bindingPath": "abc",
-  "instrumentationKey": ""
-
+  "bindingPort": 1337,
+  "bindingPath": "",
+  "instrumentationKey": "",
+  "some-job": "* * * * *",
+  "some-goober-boy": {
+    "cron": "* * * * *",
+    "timezone": "Bougainville Standard Time"
+  },
+  "some-bigboi": {
+    "cron": "* * * * *",
+    "timezone": "Samoa Standard Time"
+  }
 }


### PR DESCRIPTION
I think this meets the brief.

I ended up ditching the use of newer function signatures calls that it was warning about being obsoleted in hangfire 2.0.0 because they actually caused errors when specifying a queue name. 

The test app doesn't seem to work for me when I specify an alternate queue name, I'm not super familiar with hangfire but I'm assuming that has something to do with the default runners?

